### PR TITLE
Improve drop implementation to prevent accidental corruption

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -31,7 +31,7 @@ use lzma_stream_wrapper::LzmaStreamWrapper;
 const DEFAULT_BUF_SIZE: usize = 4 * 1024;
 
 
-pub struct LzmaWriter<T> {
+pub struct LzmaWriter<T: Write> {
 	inner: T,
 	stream: LzmaStreamWrapper,
 	buffer: Vec<u8>,
@@ -69,8 +69,9 @@ impl<T: Write> LzmaWriter<T> {
 	}
 }
 
-impl<T> Drop for LzmaWriter<T> {
+impl<T: Write> Drop for LzmaWriter<T> {
 	fn drop(&mut self) {
+		self.finish().unwrap();
 		self.stream.end()
 	}
 }


### PR DESCRIPTION
Basically, this PR just forces ```LzmaWriter``` to call ```finish``` before ending the stream. This prevents any accidental corruptions and makes it much easier to write any structs that might contain it, and makes it behave a bit more like compressors in the ```flate2``` and ```bzip2``` libraries.