### PR TITLE
pkg-config: require 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ name = "lzma"
 [dependencies]
 
 [build-dependencies]
-pkg-config = "^0.3"
+pkg-config = "^0.3.3"


### PR DESCRIPTION
0.3.2 and older do not compile with modern versions (feature flags and
old APIs).