### PR TITLE
Impl Drop for Lzmawriter

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl fmt::Display for LzmaError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			LzmaError::Io(ref err) => write!(f, "{}", err),
-			_ => write!(f, "{}", self.description()),
+			_ => write!(f, "{}", self.to_string()),
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub use writer::LzmaWriter;
 pub use error::LzmaError;
 
 
-pub const EXTREME_PRESET: u32 = (1 << 31);
+pub const EXTREME_PRESET: u32 = 1 << 31;
 
 
 /// Compress `buf` and return the result.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -73,7 +73,7 @@ impl<W: Write> LzmaWriter<W> {
 	///
 	/// This *must* be called after all writing is done to ensure the last pieces of the compressed
 	/// or decompressed stream get written out.
-	pub fn finish(mut self) {
+	pub fn finish(mut self) -> Result<(), LzmaError> {
 		loop {
 			match self.lzma_code_and_write(&[], lzma_action::LzmaFinish) {
 				Ok(LzmaCodeResult {
@@ -82,9 +82,10 @@ impl<W: Write> LzmaWriter<W> {
 					bytes_written: _,
 				}) => break,
 				Ok(_) => continue,
-				Err(_) => break,
+				Err(err) => return Err(err),
 			}
 		}
+		Ok(())
 	}
 
 	fn lzma_code_and_write(&mut self, input: &[u8], action: lzma_action) -> Result<LzmaCodeResult, LzmaError> {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -71,7 +71,7 @@ impl<T: Write> LzmaWriter<T> {
 impl<W: Write> LzmaWriter<W> {
 	/// Finalizes the LZMA stream so that it finishes compressing or decompressing.
 	///
-	/// This *must* be called after all writing is done to ensure the last pieces of the compressed
+	/// This can be called after all writing is done to ensure the last pieces of the compressed
 	/// or decompressed stream get written out.
 	pub fn finish(mut self) -> Result<(), LzmaError> {
 		loop {


### PR DESCRIPTION
I have implemented drop for the lzmawriter so that it is not mandatory to run finish().

I have unfortunately run into situations where it was no longer possible for me to execute finish(). For this purpose I have implemented what is executed in finish() in Drop. With finish(), however, the return value must then be adjusted (see pull request).

With Drop you don't get any feedback in case of an error - but you wouldn't if finish() wasn't executed.
I see no disadvantage here at the moment.